### PR TITLE
Optional DynamoDB table creation, permission for S3 locking & other improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.4
+        uses: clowdhaus/terraform-min-max@v1.3.2
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.1
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
-          terraform-docs-version: v0.16.0
+          terraform-docs-version: v0.20.0
   validate-examples:
     name: Validate examples
     runs-on: ubuntu-latest
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         working-directory: examples
     steps:
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v3
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check examples
         env:
           EXAMPLES: simple

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pre-commit-checks:
     name: Pre-commit checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
           terraform-docs-version: v0.20.0
   validate-examples:
     name: Validate examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           release-type: terraform-module

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,7 @@ on:
 name: release-please
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 config {
-  module = false
+  call_module_type = "none"
   force = false
   disabled_by_default = false
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 
 | Name | Description | Type | Required |
 |------|-------------|------|:--------:|
+| <a name="input_create_dynamodb_table"></a> [create\_dynamodb\_table](#input\_create\_dynamodb\_table) | Whether or not to create the DynamoDB table for state locking (it's deprecated for Terraform 1.11+). | `bool` | no |
 | <a name="input_dynamodb_deletion_protection_enabled"></a> [dynamodb\_deletion\_protection\_enabled](#input\_dynamodb\_deletion\_protection\_enabled) | Whether or not to enable deletion protection on the DynamoDB table | `bool` | no |
 | <a name="input_dynamodb_enable_server_side_encryption"></a> [dynamodb\_enable\_server\_side\_encryption](#input\_dynamodb\_enable\_server\_side\_encryption) | Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK) | `bool` | no |
 | <a name="input_dynamodb_table_billing_mode"></a> [dynamodb\_table\_billing\_mode](#input\_dynamodb\_table\_billing\_mode) | Controls how you are charged for read and write throughput and how you manage capacity. | `string` | no |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 | <a name="input_s3_logging_target_prefix"></a> [s3\_logging\_target\_prefix](#input\_s3\_logging\_target\_prefix) | The prefix to apply on bucket logs, e.g "logs/". | `string` | no |
 | <a name="input_state_bucket_prefix"></a> [state\_bucket\_prefix](#input\_state\_bucket\_prefix) | Creates a unique state bucket name beginning with the specified prefix. | `string` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resources. | `map(string)` | no |
+| <a name="input_terraform_iam_policy_add_lockfile_permissions"></a> [terraform\_iam\_policy\_add\_lockfile\_permissions](#input\_terraform\_iam\_policy\_add\_lockfile\_permissions) | Whether to add permissions for the S3 lockfile (recommended for Terraform 1.11+). | `bool` | no |
 | <a name="input_terraform_iam_policy_create"></a> [terraform\_iam\_policy\_create](#input\_terraform\_iam\_policy\_create) | Specifies whether to terraform IAM policy is created. | `bool` | no |
 | <a name="input_terraform_iam_policy_name"></a> [terraform\_iam\_policy\_name](#input\_terraform\_iam\_policy\_name) | If override\_terraform\_iam\_policy\_name is true, use this policy name instead of dynamic name with policy\_prefix | `string` | no |
 | <a name="input_terraform_iam_policy_name_prefix"></a> [terraform\_iam\_policy\_name\_prefix](#input\_terraform\_iam\_policy\_name\_prefix) | Creates a unique name beginning with the specified prefix. | `string` | no |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 
 - Starting from v1.0, this module requires [Terraform Provider for AWS](https://github.com/terraform-providers/terraform-provider-aws) v4.0 or later. [Version 1.0 Upgrade Guide](./docs/upgrade-1.0.md) described the recommended procedure after the upgrade.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -112,8 +112,8 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 | <a name="input_kms_key_deletion_window_in_days"></a> [kms\_key\_deletion\_window\_in\_days](#input\_kms\_key\_deletion\_window\_in\_days) | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. | `number` | no |
 | <a name="input_kms_key_description"></a> [kms\_key\_description](#input\_kms\_key\_description) | The description of the key as viewed in AWS console. | `string` | no |
 | <a name="input_kms_key_enable_key_rotation"></a> [kms\_key\_enable\_key\_rotation](#input\_kms\_key\_enable\_key\_rotation) | Specifies whether key rotation is enabled. | `bool` | no |
-| <a name="input_noncurrent_version_expiration"></a> [noncurrent\_version\_expiration](#input\_noncurrent\_version\_expiration) | Specifies when noncurrent object versions expire. See the aws\_s3\_bucket document for detail. | <pre>object({<br>    days = number<br>  })</pre> | no |
-| <a name="input_noncurrent_version_transitions"></a> [noncurrent\_version\_transitions](#input\_noncurrent\_version\_transitions) | Specifies when noncurrent object versions transitions. See the aws\_s3\_bucket document for detail. | <pre>list(object({<br>    days          = number<br>    storage_class = string<br>  }))</pre> | no |
+| <a name="input_noncurrent_version_expiration"></a> [noncurrent\_version\_expiration](#input\_noncurrent\_version\_expiration) | Specifies when noncurrent object versions expire. See the aws\_s3\_bucket document for detail. | <pre>object({<br/>    days = number<br/>  })</pre> | no |
+| <a name="input_noncurrent_version_transitions"></a> [noncurrent\_version\_transitions](#input\_noncurrent\_version\_transitions) | Specifies when noncurrent object versions transitions. See the aws\_s3\_bucket document for detail. | <pre>list(object({<br/>    days          = number<br/>    storage_class = string<br/>  }))</pre> | no |
 | <a name="input_override_iam_policy_name"></a> [override\_iam\_policy\_name](#input\_override\_iam\_policy\_name) | override iam policy name to disable policy\_prefix and create policy with static name | `bool` | no |
 | <a name="input_override_iam_role_name"></a> [override\_iam\_role\_name](#input\_override\_iam\_role\_name) | override iam role name to disable role\_prefix and create role with static name | `bool` | no |
 | <a name="input_override_s3_bucket_name"></a> [override\_s3\_bucket\_name](#input\_override\_s3\_bucket\_name) | override s3 bucket name to disable bucket\_prefix and create bucket with static name | `bool` | no |
@@ -141,4 +141,4 @@ See [the official document](https://www.terraform.io/docs/backends/types/s3.html
 | <a name="output_replica_bucket"></a> [replica\_bucket](#output\_replica\_bucket) | The S3 bucket to replicate the state S3 bucket. |
 | <a name="output_state_bucket"></a> [state\_bucket](#output\_state\_bucket) | The S3 bucket to store the remote state file. |
 | <a name="output_terraform_iam_policy"></a> [terraform\_iam\_policy](#output\_terraform\_iam\_policy) | The IAM Policy to access remote state environment. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/dynamo.tf
+++ b/dynamo.tf
@@ -10,6 +10,8 @@ locals {
 }
 
 resource "aws_dynamodb_table" "lock" {
+  count = var.create_dynamodb_table ? 1 : 0
+
   name                        = var.dynamodb_table_name
   billing_mode                = var.dynamodb_table_billing_mode
   hash_key                    = local.lock_key_id

--- a/examples/simple-terraform-1-11/main.tf
+++ b/examples/simple-terraform-1-11/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 0.15"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "replica"
+  region = var.replica_region
+}
+
+module "remote_state" {
+  source = "../../"
+
+  # Do not create the DynamoDB lock table
+  create_dynamodb_table = false
+  # Instead, add S3 lock file permissions to the IAM policy
+  terraform_iam_policy_add_lockfile_permissions = true
+
+  providers = {
+    aws         = aws
+    aws.replica = aws.replica
+  }
+}
+
+resource "aws_iam_user" "terraform" {
+  name = "TerraformUser"
+}
+
+resource "aws_iam_user_policy_attachment" "remote_state_access" {
+  user       = aws_iam_user.terraform.name
+  policy_arn = module.remote_state.terraform_iam_policy.arn
+}

--- a/examples/simple-terraform-1-11/outputs.tf
+++ b/examples/simple-terraform-1-11/outputs.tf
@@ -1,0 +1,9 @@
+output "kms_key" {
+  description = "The KMS customer master key to encrypt state buckets."
+  value       = module.remote_state.kms_key.key_id
+}
+
+output "state_bucket" {
+  description = "The S3 bucket to store the remote state file."
+  value       = module.remote_state.state_bucket.bucket
+}

--- a/examples/simple-terraform-1-11/variables.tf
+++ b/examples/simple-terraform-1-11/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "The AWS region in which resources are set up."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "replica_region" {
+  description = "The AWS region to which the state bucket is replicated."
+  type        = string
+  default     = "us-west-1"
+}

--- a/migrations.tf
+++ b/migrations.tf
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------------------
-# Migrations to 0.7.0
+# Migrations
 # --------------------------------------------------------------------------------------------------
 
 moved {
@@ -22,3 +22,7 @@ moved {
   to   = aws_s3_bucket_policy.replica_force_ssl[0]
 }
 
+moved {
+  from = aws_dynamodb_table.lock
+  to   = aws_dynamodb_table.lock[0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "replica_bucket" {
 
 output "dynamodb_table" {
   description = "The DynamoDB table to manage lock states."
-  value       = aws_dynamodb_table.lock
+  value       = var.create_dynamodb_table ? aws_dynamodb_table.lock[0] : null
 }
 
 output "kms_key_replica" {

--- a/policy.tf
+++ b/policy.tf
@@ -19,10 +19,13 @@ data "aws_iam_policy_document" "terraform" {
   }
 
   statement {
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject"
-    ]
+    actions = concat(
+      [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      var.terraform_iam_policy_add_lockfile_permissions ? ["s3:DeleteObject"] : []
+    )
     resources = ["${aws_s3_bucket.state.arn}/*"]
   }
 

--- a/policy.tf
+++ b/policy.tf
@@ -26,14 +26,17 @@ data "aws_iam_policy_document" "terraform" {
     resources = ["${aws_s3_bucket.state.arn}/*"]
   }
 
-  statement {
-    actions = [
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem",
-      "dynamodb:DescribeTable"
-    ]
-    resources = [aws_dynamodb_table.lock[0].arn]
+  dynamic "statement" {
+    for_each = var.create_dynamodb_table ? [1] : []
+    content {
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable"
+      ]
+      resources = [aws_dynamodb_table.lock[0].arn]
+    }
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "terraform_iam_policy_name_prefix" {
   default     = "terraform"
 }
 
+variable "terraform_iam_policy_add_lockfile_permissions" {
+  description = "Whether to add permissions for the S3 lockfile (recommended for Terraform 1.11+)."
+  type        = bool
+  default     = false
+}
+
 #---------------------------------------------------------------------------------------------------
 # KMS Key for Encrypting S3 Buckets
 #---------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,12 @@ variable "s3_logging_target_prefix" {
 # DynamoDB Table for State Locking
 #---------------------------------------------------------------------------------------------------
 
+variable "create_dynamodb_table" {
+  description = "Whether or not to create the DynamoDB table for state locking (it's deprecated for Terraform 1.11+)."
+  type        = bool
+  default     = true
+}
+
 variable "dynamodb_table_name" {
   description = "The name of the DynamoDB table to use for state locking."
   type        = string


### PR DESCRIPTION
- **feat: Updated pre-commit-terraform hook**
- **fix: Update deprecated option in tflint configuration**
- **refactor: Use data source for Terraform policy**
- **feat: Make DynamoDB table creation optional**
- **feat: Support for S3 lock file IAM permissions**
- **feat: Module use example for Terraform 1.11+**
- **feat: Updated actions used in GHA workflows**
- **feat: Use Ubuntu 24.04 runners instead of latest in GHA workflows**
