### PR TITLE
Fix: Resolve deprecation warnings

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -115,6 +115,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "state" {
     id     = "auto-archive"
     status = "Enabled"
 
+    filter {}
+
     dynamic "noncurrent_version_transition" {
       for_each = var.noncurrent_version_transitions
 

--- a/replica.tf
+++ b/replica.tf
@@ -229,6 +229,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "replica" {
     id     = "auto-archive"
     status = "Enabled"
 
+    filter {}
+
     dynamic "noncurrent_version_transition" {
       for_each = var.noncurrent_version_transitions
 


### PR DESCRIPTION
This PR addresses a warnings received when I imported your module:
```
╷
│ Warning: Invalid Attribute Combination
│ 
│   with module.remote_state.aws_s3_bucket_lifecycle_configuration.state,
│   on .terraform/modules/remote_state/bucket.tf line 110, in resource "aws_s3_bucket_lifecycle_configuration" "state":
│  110: resource "aws_s3_bucket_lifecycle_configuration" "state" {
│ 
│ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
│ 
│ This will be an error in a future version of the provider
│ 
│ (and one more similar warning elsewhere)
╵
```