### PR TITLE
fix: Use aws_service data sources instead of aws_region for AWS provider v4-v6 compatibility

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -2,9 +2,6 @@ locals {
   define_lifecycle_rule = var.noncurrent_version_expiration != null || length(var.noncurrent_version_transitions) > 0
 }
 
-data "aws_region" "state" {
-}
-
 #---------------------------------------------------------------------------------------------------
 # KMS Key to Encrypt S3 Bucket
 #---------------------------------------------------------------------------------------------------

--- a/dynamo.tf
+++ b/dynamo.tf
@@ -34,7 +34,7 @@ resource "aws_dynamodb_table" "lock" {
   dynamic "replica" {
     for_each = var.enable_replication == true ? [1] : []
     content {
-      region_name = data.aws_region.replica[0].name
+      region_name = data.aws_service.s3_replica[0].region
       kms_key_arn = var.dynamodb_enable_server_side_encryption ? aws_kms_key.replica[0].arn : null
     }
   }

--- a/replica.tf
+++ b/replica.tf
@@ -2,9 +2,15 @@ locals {
   replication_role_count = var.iam_role_arn == null && var.enable_replication ? 1 : 0
 }
 
-data "aws_region" "replica" {
-  count    = var.enable_replication ? 1 : 0
-  provider = aws.replica
+data "aws_service" "s3" {
+  count      = var.enable_replication ? 1 : 0
+  service_id = "s3"
+}
+
+data "aws_service" "s3_replica" {
+  count      = var.enable_replication ? 1 : 0
+  service_id = "s3"
+  provider   = aws.replica
 }
 
 #---------------------------------------------------------------------------------------------------
@@ -80,7 +86,7 @@ data "aws_iam_policy_document" "replication" {
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.state.name}.amazonaws.com"]
+      values   = [data.aws_service.s3[0].dns_name]
     }
     condition {
       test     = "StringLike"
@@ -97,7 +103,7 @@ data "aws_iam_policy_document" "replication" {
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.replica[0].name}.amazonaws.com"]
+      values   = [data.aws_service.s3_replica[0].dns_name]
     }
     condition {
       test     = "StringLike"


### PR DESCRIPTION
- **refactor: Replication IAM policies as data sources**
- **fix: Use aws_service data sources instead of aws_region for AWS provider v4-v6 compatibility**
